### PR TITLE
Adopt new releases

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -333,7 +333,7 @@ Next we want to adopt the Java 17 runtime.
 
 === Replace Cobertura with JaCoCo
 To prepare for our Java 17 migration, we first need fix the outdated
-http://cobertura.github.io/cobertura/[Cobertura] code coverage plugin.
+http://cobertura.github.io/cobertura/[Cobertura] code coverage plugin,
 which we can best replace with the more modern
 https://www.eclemma.org/jacoco/[JaCoCo].
 We cheat just a little bit by cherry picking that change out of the main branch.

--- a/README.adoc
+++ b/README.adoc
@@ -243,14 +243,14 @@ We invoke the rewrite plugin `configure` goal for the plugin to update it's own 
 [source,bash]
 ----
 ./mvnw rewrite:configure \
-  -Ddependencies=org.openrewrite.recipe:rewrite-spring:4.19.0 \
+  -Ddependencies=org.openrewrite.recipe:rewrite-spring:4.19.1 \
   -DactiveRecipes=org.openrewrite.java.spring.boot2.SpringBoot1To2Migration
 ----
 
 NOTE: The `configure` goal only works if the plugin is already present; if not replace `rewrite:configure` with `org.openrewrite.maven:rewrite-maven-plugin:4.22.0:init`.
 
 We can again see how the
-https://github.com/openrewrite/rewrite-spring/blob/v4.19.0/src/main/resources/META-INF/rewrite/spring-boot2.yml[SpringBoot1To2Migration] is composed of finer grained recipes.
+https://github.com/openrewrite/rewrite-spring/blob/v4.19.1/src/main/resources/META-INF/rewrite/spring-boot2.yml[SpringBoot1To2Migration] is composed of finer grained recipes.
 If you look closely these migration takes us first to 2.0.x, then 2.1.x, 2.2.x, all the way through to 2.5.x at present, with 2.6.x still in development.
 As indicated above a JUnit 5 migration will be executed as part of the Spring Boot 2.4.x migration.
 
@@ -476,7 +476,7 @@ Be sure to reach out if you encounter any issues; I've found the folks behind Op
 
 - rewrite-maven-plugin:4.22.0
 - rewrite-migrate-java:1.4.0
-- rewrite-spring:4.19.0
+- rewrite-spring:4.19.1
 - rewrite-testing-frameworks:1.20.0
 - Java 8.0.322 Temurin
 - Java 17.0.2 Temurin

--- a/README.adoc
+++ b/README.adoc
@@ -75,8 +75,8 @@ Let's get OpenRewrite set up to apply our first automated migration:
 
 [source,bash]
 ----
-./mvnw org.openrewrite.maven:rewrite-maven-plugin:4.21.0:init \ # <1>
-  -Ddependencies=org.openrewrite.recipe:rewrite-testing-frameworks:1.19.0 \ # <2>
+./mvnw org.openrewrite.maven:rewrite-maven-plugin:4.22.0:init \ # <1>
+  -Ddependencies=org.openrewrite.recipe:rewrite-testing-frameworks:1.20.0 \ # <2>
   -DactiveRecipes=org.openrewrite.java.testing.junit5.JUnit5BestPractices # <3>
 git diff # <4>
 ----
@@ -85,7 +85,7 @@ https://github.com/openrewrite/rewrite-maven-plugin/commit/5eb473459c89b3d2e6872
 <2> We add a dependency on
 https://github.com/openrewrite/rewrite-testing-frameworks[rewrite-testing-frameworks] to the plugin.
 <3> We activate
-https://github.com/openrewrite/rewrite-testing-frameworks/blob/v1.19.0/src/main/resources/META-INF/rewrite/junit5.yml#L18[the JUnit5BestPractices recipe].
+https://github.com/openrewrite/rewrite-testing-frameworks/blob/v1.20.0/src/main/resources/META-INF/rewrite/junit5.yml#L18[the JUnit5BestPractices recipe].
 <4> The diff should show the plugin added to the project.
 
 .`pom.xml` build plugin added after `init`
@@ -122,10 +122,10 @@ index 6fdc4d1..755b35a 100644
 ----
 
 If you take a closer look at the added
-https://github.com/openrewrite/rewrite-testing-frameworks/blob/v1.19.0/src/main/resources/META-INF/rewrite/junit5.yml#L18[JUnit5BestPractices recipe],
+https://github.com/openrewrite/rewrite-testing-frameworks/blob/v1.20.0/src/main/resources/META-INF/rewrite/junit5.yml#L18[JUnit5BestPractices recipe],
 you'll find it's composed of a `recipeList`, with references defined further down.
 Note how
-https://github.com/openrewrite/rewrite-testing-frameworks/blob/v1.19.0/src/main/resources/META-INF/rewrite/junit5.yml#L46[the `recipeList` under `JUnit4to5Migration`] matches some of the migration steps we identified above.
+https://github.com/openrewrite/rewrite-testing-frameworks/blob/v1.20.0/src/main/resources/META-INF/rewrite/junit5.yml#L46[the `recipeList` under `JUnit4to5Migration`] matches some of the migration steps we identified above.
 This is a common pattern with OpenRewrite recipes; complex migrations are composed of more fine grained recipes, each of which applies a small step in the full migration.
 
 === Run JUnit 5 migration
@@ -243,14 +243,14 @@ We invoke the rewrite plugin `configure` goal for the plugin to update it's own 
 [source,bash]
 ----
 ./mvnw rewrite:configure \
-  -Ddependencies=org.openrewrite.recipe:rewrite-spring:4.19.0-SNAPSHOT \
+  -Ddependencies=org.openrewrite.recipe:rewrite-spring:4.19.0 \
   -DactiveRecipes=org.openrewrite.java.spring.boot2.SpringBoot1To2Migration
 ----
 
-NOTE: The `configure` goal only works if the plugin is already present; if not replace `rewrite:configure` with `org.openrewrite.maven:rewrite-maven-plugin:4.21.0:init`.
+NOTE: The `configure` goal only works if the plugin is already present; if not replace `rewrite:configure` with `org.openrewrite.maven:rewrite-maven-plugin:4.22.0:init`.
 
 We can again see how the
-https://github.com/openrewrite/rewrite-spring/blob/v4.18.0/src/main/resources/META-INF/rewrite/spring-boot2.yml[SpringBoot1To2Migration] is composed of finer grained recipes.
+https://github.com/openrewrite/rewrite-spring/blob/v4.19.0/src/main/resources/META-INF/rewrite/spring-boot2.yml[SpringBoot1To2Migration] is composed of finer grained recipes.
 If you look closely these migration takes us first to 2.0.x, then 2.1.x, 2.2.x, all the way through to 2.5.x at present, with 2.6.x still in development.
 As indicated above a JUnit 5 migration will be executed as part of the Spring Boot 2.4.x migration.
 
@@ -329,7 +329,22 @@ When we now run the tests again, all tests will pass.
 That means our migration to Spring Boot 2.5 and JUnit 5 worked!
 
 == Upgrade to Java 17
-Next we want to adopt the Java 17 runtime, for whch we need yet another dependency and recipe.
+Next we want to adopt the Java 17 runtime.
+
+=== Replace Cobertura with JaCoCo
+To prepare for our Java 17 migration, we first need fix the outdated
+http://cobertura.github.io/cobertura/[Cobertura] code coverage plugin.
+which we can best replace with the more modern
+https://www.eclemma.org/jacoco/[JaCoCo].
+We cheat just a little bit by cherry picking that change out of the main branch.
+
+[source,bash]
+----
+git cherry-pick 60105d5d9a8b64d29927b98cd06d6d811fd4bb52
+----
+
+=== Java8toJava11 recipe
+To upgrade our application itself we need yet another dependency and recipe.
 We will run the
 https://github.com/openrewrite/rewrite-migrate-java/blob/main/src/main/resources/META-INF/rewrite/java8-to-java11.yml#L18[Java8toJava11] recipe, which comprises a number of fixes to be compatible with Java 11 runtime.
 There's no need for a recipe yet to explicitly upgrade to Java 17.
@@ -337,7 +352,7 @@ There's no need for a recipe yet to explicitly upgrade to Java 17.
 [source,bash]
 ----
 ./mvnw rewrite:configure \
-  -Ddependencies=org.openrewrite.recipe:rewrite-migrate-java:1.3.0 \
+  -Ddependencies=org.openrewrite.recipe:rewrite-migrate-java:1.4.0 \
   -DactiveRecipes=org.openrewrite.java.migrate.Java8toJava11
 ./mvnw rewrite:run
 ----
@@ -383,8 +398,10 @@ index 681a480..5c59ee0 100644
 https://www.oracle.com/java/technologies/javase/11-relnote-issues.html#JDK-8190378[Java 11 removed the Java EE modules], which is why we need `jaxb-impl` when running on Java 11+.
 The
 https://maven.apache.org/plugins/maven-jdeprscan-plugin/jdeprscan-mojo.html[maven-jdeprscan-plugin] surfaces any incompatibilities when running the `jdeprscan` goal on Java 11+.
+Along the way 
+https://alexo.github.io/wro4j/[Wro4j] and JaCoCo are updated to their latest versions as well.
 
-Unfortunately, when we swich to Java 17 we can see there's a few minor fixes we need to apply still.
+When we run our tests on Java 17 we can see we are now compatible with the Java 17 runtime.
 
 [source,bash]
 ----
@@ -392,36 +409,6 @@ sdk use java 17.0.2-tem
 ./mvnw verify
 ----
 
-=== Upgrade Wro4j and replace Cobertura with JaCoCo
-The build still uses problematic old versions of
-https://github.com/wro4j/wro4j[`wro4j`] and http://cobertura.github.io/cobertura/[Cobertura].
-The former we can upgrade, but the latter we can best replace with the more modern
-https://www.eclemma.org/jacoco/[JaCoCo].
-We cheat just a little bit by cherry picking out of the main branch, after which we patch both `wro4j` and `JaCoCo`.
-
-[source,diff]
-----
-git cherry-pick 60105d5d9a8b64d29927b98cd06d6d811fd4bb52
-patch -p1 << EOF
-diff --git a/pom.xml b/pom.xml
-index 3c16dac..12a6372 100644
---- a/pom.xml
-+++ b/pom.xml
-@@ -25,9 +25,9 @@
-     <webjars-bootstrap.version>3.3.6</webjars-bootstrap.version>
-     <webjars-jquery-ui.version>1.11.4</webjars-jquery-ui.version>
-     <webjars-jquery.version>2.2.4</webjars-jquery.version>
--    <wro4j.version>1.8.0</wro4j.version>
-+    <wro4j.version>1.10.1</wro4j.version>
- 
--    <jacoco.version>0.8.1</jacoco.version>
-+    <jacoco.version>0.8.7</jacoco.version>
- 
-   </properties>
-EOF
-----
-
-That's enough to resolve our build issues; we're now compatible with the Java 17 runtime.
 Our source level is still at 1.8 though, so we can not yet use any new language feautures.
 
 === Patch java.version
@@ -487,10 +474,10 @@ Be sure to reach out if you encounter any issues; I've found the folks behind Op
 
 == Versions used
 
-- rewrite-maven-plugin:4.21.0
-- rewrite-migrate-java:1.3.0
-- rewrite-spring:4.19.0-SNAPSHOT
-- rewrite-testing-frameworks:1.19.0
+- rewrite-maven-plugin:4.22.0
+- rewrite-migrate-java:1.4.0
+- rewrite-spring:4.19.0
+- rewrite-testing-frameworks:1.20.0
 - Java 8.0.322 Temurin
 - Java 17.0.2 Temurin
 - Apache Maven 3.8.5


### PR DESCRIPTION
Still waiting on the new release binaries to show up in Maven Central:
https://repo1.maven.org/maven2/org/openrewrite/maven/rewrite-maven-plugin/4.22.0/
And yet another new release of rewrite-spring to pick up rewrite-testing-frameworks.